### PR TITLE
Add Artist creation endpoint

### DIFF
--- a/handlers/artists.go
+++ b/handlers/artists.go
@@ -1,0 +1,83 @@
+package handlers
+
+import (
+	"fmt"
+	"github.com/AnthonyNixon/setsisaw/auth"
+	"github.com/AnthonyNixon/setsisaw/database"
+	"github.com/AnthonyNixon/setsisaw/types"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+func NewArtist(c *gin.Context) {
+	// Check Auth info
+	claims, customErr := auth.GetUserInfo(c)
+	if customErr != nil {
+		c.JSON(customErr.StatusCode(), gin.H{"error": customErr.Description()})
+		return
+	}
+
+	// TODO: This shouldn't be an editor only function. Anyone should be able to add an artist. This is just for testing claims.
+	if !auth.IsEntitled(claims, "EDITOR") {
+		c.JSON(http.StatusForbidden, gin.H{"Error": fmt.Sprintf("User %s is not entitled to add an artist.", claims.Username)})
+		return
+	}
+
+	// If we're here, the user is authorized to add an artist.
+
+	var newArtist types.Artist
+	err := c.BindJSON(&newArtist)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"Error": "Bad JSON Input, could not bind."})
+		return
+	}
+
+	unique, err := isNewArtistUnique(newArtist)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if !unique {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Artist already created"})
+		return
+	}
+
+
+	db, err := database.GetConnection()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	defer db.Close()
+
+	stmt, err := db.Prepare("insert into artists (name) values(?);")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	_, err = stmt.Exec(newArtist.Name)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{"name": newArtist.Name})
+}
+
+func isNewArtistUnique(newArtist types.Artist) (bool, error) {
+	db, err := database.GetConnection()
+	if err != nil {
+		return false, err
+	}
+	defer db.Close()
+
+	var count int
+	err = db.QueryRow("select COUNT(*) FROM artists where name = ?", newArtist.Name).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+
+	return count == 0, nil
+}

--- a/handlers/authcheck.go
+++ b/handlers/authcheck.go
@@ -7,11 +7,11 @@ import (
 )
 
 func AuthCheck(c *gin.Context) {
-	username, err := auth.GetUsernameFromAuthHeader(c)
+	claims, err := auth.GetUserInfo(c)
 	if err != nil {
 		c.JSON(err.StatusCode(), gin.H{"error": err.Description()})
 		return
 	}
 
-	c.String(http.StatusOK, username)
+	c.JSON(http.StatusOK, claims)
 }

--- a/main.go
+++ b/main.go
@@ -33,6 +33,9 @@ func main() {
 
 	r.GET("/refresh", handlers.RefreshToken)
 
+	// Artists
+	r.POST("/artists", handlers.NewArtist)
+
 	log.Printf("Running SetsISaw API on :%s...", PORT)
 	err := r.Run(fmt.Sprintf(":%s", PORT)) // listen and serve on 0.0.0.0:8080
 	if err != nil {

--- a/types/types.go
+++ b/types/types.go
@@ -8,7 +8,12 @@ type User struct {
 	Password string `json:"password"`
 	FirstName string `json:"first_name"`
 	LastName string `json:"last_name"`
-	Location string `json:"location"`
+	Id int `json:"id"`
+}
+
+type Artist struct {
+	Name string `json:"name"`
+	Id int `json:"id"`
 }
 
 type Claims struct {

--- a/users/users.go
+++ b/users/users.go
@@ -23,6 +23,11 @@ func SignUp(c *gin.Context) {
 		return
 	}
 
+	if newUser.Email == "" || newUser.Username == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Must include email and username"})
+		return
+	}
+
 	unique, err := isNewUserUnique(newUser)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error2": err.Error()})
@@ -49,13 +54,13 @@ func SignUp(c *gin.Context) {
 	}
 	defer db.Close()
 
-	stmt, err := db.Prepare("insert into users (username, email, password) values(?,?,?);")
+	stmt, err := db.Prepare("insert into users (username, email, password, first_name, last_name) values(?,?,?,?,?);")
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	_, err = stmt.Exec(newUser.Username, newUser.Email, hashedPassword)
+	_, err = stmt.Exec(newUser.Username, newUser.Email, hashedPassword, newUser.FirstName, newUser.LastName)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, err.Error())
 		return


### PR DESCRIPTION
Resolves #3 
Adds the first name and last name fields to the database.

Resolves #7 
Adds a `POST` endpoint on `/artists` to create a new artist. This is currently restricted to admins and editors. 